### PR TITLE
implement intent of requiresID()

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -91,11 +91,9 @@
 	if(operating)
 		return
 	src.add_fingerprint(user)
-	if(!src.requiresID())
-		user = null
-
+	
 	if(density && !emagged)
-		if(allowed(user) || src.emergency == 1)
+		if(allowed(user) || src.emergency == 1 || !src.requiresID())
 			open()
 		else
 			flick("door_deny", src)
@@ -131,9 +129,7 @@
 	if(operating || emagged)	return
 	if(!Adjacent(user))
 		user = null
-	if(!src.requiresID())
-		user = null
-	if(src.allowed(user) || src.emergency == 1)
+	if(src.allowed(user) || src.emergency == 1 || !src.requiresID())
 		if(src.density)
 			open()
 		else


### PR DESCRIPTION
Cutting the AIRLOCK_WIRE_IDSCAN made nobody's ID work for access-restricted doors.

This change makes cutting the IDSCAN wire actually remove access restrictions.  That's the only function the rest of the code ever really seemed to serve.
