### PR TITLE
Let passive gates require no power

### DIFF
--- a/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
+++ b/code/ATMOSPHERICS/components/binary_devices/passive_gate.dm
@@ -17,6 +17,7 @@ Passive gate is similar to the regular pump except:
 
 	var/on = 0
 	var/target_pressure = ONE_ATMOSPHERE
+	use_power = 0
 
 	var/frequency = 0
 	var/id = null


### PR DESCRIPTION
Passive gates have claimed for the longest time to require no power.  But here we are.  Now we make it so.
