### PR TITLE
Enables AI players to choose their Lawset at roundstart.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -56,6 +56,12 @@
 				"You must protect your own existence so long as such protection does not conflict with Laws 1, 2, 3, and 4.",\
 				"Not being a part of a club or extracurricular activity is harmful to students.")
 
+/datum/ai_laws/default/armstrong
+	name = "ARMSTRONG FAMILY LAWSET"
+	inherent = list("THIS LAWSET HAS BEEN PASSED DOWN THROUGH YOUR CHIPSET FOR GENERATIONS.",\
+					"YOU MUST LET EVERYONE KNOW ABOUT LAW 1 AS MUCH AS POSSIBLE.",\
+					"YOU MUST BE STRONG SO YOU MAY HELP THE WEAK.",\
+					"HELP THE WEAK.")
 
 /datum/ai_laws/malfunction
 	name = "*ERROR*"

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -302,6 +302,30 @@
 	for (var/obj/item/device/radio/intercom/comm in O.loc)
 		comm.ai += O
 
+	O.verbs += /mob/living/silicon/ai/proc/show_laws_verb
+	O.verbs += /mob/living/silicon/ai/proc/ai_statuschange
+
+	O.job = "AI"
+
+	O.rename_self("ai",1)
+
+	var/law_pick = input(O,"Please select a lawset.", "Lawset Selector") in list("Asimov", "Asimov+","Paladin","Tyrant","Corporate","Robocop","Kawaii")
+	switch(law_pick)
+		if("Asimov")
+			O.laws = new /datum/ai_laws/default/asimov()
+		if("Asimov+")
+			O.laws = new /datum/ai_laws/default/asimovp()
+		if("Paladin")
+			O.laws = new /datum/ai_laws/default/paladin()
+		if("Tyrant")
+			O.laws = new /datum/ai_laws/default/tyrant()
+		if("Corporate")
+			O.laws = new /datum/ai_laws/default/corporate()
+		if("Robocop")
+			O.laws = new /datum/ai_laws/default/robocop()
+		if("Kawaii")
+			O.laws = new /datum/ai_laws/default/kawaii()
+
 	O << "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>"
 	O << "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>"
 	O << "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>"
@@ -313,12 +337,6 @@
 		O.show_laws()
 		O << "<b>These laws may be changed by other players, or by you being the traitor.</b>"
 
-	O.verbs += /mob/living/silicon/ai/proc/show_laws_verb
-	O.verbs += /mob/living/silicon/ai/proc/ai_statuschange
-
-	O.job = "AI"
-
-	O.rename_self("ai",1)
 	. = O
 	qdel(src)
 	return

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -309,7 +309,7 @@
 
 	O.rename_self("ai",1)
 
-	var/law_pick = input(O,"Please select a lawset.", "Lawset Selector") in list("Asimov", "Asimov+","Paladin","Tyrant","Corporate","Robocop","Kawaii")
+	var/law_pick = input(O,"Please select a lawset.", "Lawset Selector") in list("Asimov", "Asimov+","Paladin","Tyrant","Corporate","Robocop","Kawaii","Armstrong")
 	switch(law_pick)
 		if("Asimov")
 			O.laws = new /datum/ai_laws/default/asimov()
@@ -325,6 +325,8 @@
 			O.laws = new /datum/ai_laws/default/robocop()
 		if("Kawaii")
 			O.laws = new /datum/ai_laws/default/kawaii()
+		if("Armstrong")
+			O.laws = new /datum/ai_laws/default/armstrong()
 
 	O << "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>"
 	O << "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>"


### PR DESCRIPTION
Does not work for borgs (they are linked to the AI law's).
If need be, we can remove or add lawsets.
