### PR TITLE
Fix Disablers

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -737,7 +737,7 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/Exhaust()
 	src << "<span class='notice'>You're too exhausted to keep going...</span>"
-	Weaken(5)
+	AdjustWeakened(min(max(staminaloss -100,100),30))	//keeping weaken values between 100 or 30 on Exhaust() otherwise disablers only floor people for 5 ticks. Ridiculous.
 
 /mob/living/update_gravity(has_gravity)
 	if(!ticker)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -737,7 +737,7 @@ Sorry Giacom. Please don't be mad :(
 
 /mob/living/proc/Exhaust()
 	src << "<span class='notice'>You're too exhausted to keep going...</span>"
-	AdjustWeakened(min(max(staminaloss -100,100),30))	//keeping weaken values between 100 or 30 on Exhaust() otherwise disablers only floor people for 5 ticks. Ridiculous.
+	AdjustWeakened(min(max(staminaloss -100,50-weakened),15))	//keeping weaken values between 15 (9 seconds) and a maximum of 50 (30 seconds) on Exhaust() otherwise disablers only floor people for 5 ticks. A maximum of 50 to prevent someone from disabling people for 2 hours.
 
 /mob/living/update_gravity(has_gravity)
 	if(!ticker)


### PR DESCRIPTION
Disablers are pathetic because of the "Weakened" var.
Exhaust only sets it to 5, and thus, people are only floored for 5
ticks.
Upped it to a maximum of 100, minimum of 30, depending on stamina
damage.
Also changed it to "adjustweaken" so multiple disabler shots are
cumulative.
