### PR TITLE
Cultist Constructs buffs

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -79,14 +79,15 @@
 	desc = "A possessed suit of armor driven by the will of the restless dead."
 	icon_state = "behemoth"
 	icon_living = "behemoth"
-	maxHealth = 250
+	maxHealth = 320 // Buffed max health but not starting health, good sinergy with artificer
 	health = 250
 	response_harm   = "harmlessly punches"
 	harm_intent_damage = 0
 	melee_damage_lower = 30
-	melee_damage_upper = 30
+	melee_damage_upper = 40  // Slightly buff to max damage, if you get hit by this slowass guy you deserve it
 	attacktext = "smashes their armored gauntlet into"
 	speed = 3
+	see_in_dark = 7 // why the fuck couldn't he see in dark before?
 	environment_smash = 2
 	attack_sound = 'sound/weapons/punch3.ogg'
 	status_flags = 0
@@ -94,14 +95,14 @@
 	force_threshold = 11
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/lesserforcewall)
 	playstyle_string = "<B>You are a Juggernaut. Though slow, your shell can withstand extreme punishment, \
-						create shield walls and even deflect energy weapons, and rip apart enemies and walls alike.</B>"
+						create shield walls and even deflect energy weapons, and rip apart enemies and walls alike.You do not start with your HP maxed, seek an artificer to get you to full health</B>" // now reflects the health changes
 
 /mob/living/simple_animal/construct/armored/bullet_act(var/obj/item/projectile/P)
 	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
-		var/reflectchance = 80 - round(P.damage/3)
+		var/reflectchance = 90 // big chance to reflect energy weapons, making them the tank they should be.
 		if(prob(reflectchance))
 			if(P.damage_type == BURN || P.damage_type == BRUTE)
-				adjustBruteLoss(P.damage * 0.5)
+				adjustBruteLoss(P.damage * 0.25) // small damage taken if the weapon gets deflected
 			visible_message("<span class='danger'>The [P.name] gets reflected by [src]'s shell!</span>", \
 							"<span class='userdanger'>The [P.name] gets reflected by [src]'s shell!</span>")
 
@@ -129,7 +130,7 @@
 
 
 
-/mob/living/simple_animal/construct/wraith
+/mob/living/simple_animal/construct/wraith // Can now slash at APCs too
 	name = "Wraith"
 	real_name = "Wraith"
 	desc = "A wicked bladed shell contraption piloted by a bound spirit"
@@ -137,14 +138,15 @@
 	icon_living = "floating"
 	maxHealth = 75
 	health = 75
-	melee_damage_lower = 25
+	melee_damage_lower = 20    //Debuff to compensate for new powers
 	melee_damage_upper = 25
 	attacktext = "slashes"
 	speed = 0
 	see_in_dark = 7
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
-	playstyle_string = "<B>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</B>"
+	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift, /obj/effect/proc_holder/spell/targeted/smoke/disable) // they now get para smoke too!
+	playstyle_string = "<B>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls. Disable enemies with your special smoke and subdue them with your sharp claws</B>"
+
 
 
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -639,6 +639,27 @@
 	else
 		beenhit += 1
 	return
+	
+/obj/machinery/power/apc/attack_alien(simple_animal/construct/wraith) // Wraiths can now slash at APCs
+	if(!user)
+		return
+	user.changeNext_move(CLICK_CD_MELEE)
+	user.do_attack_animation(src)
+	user.visible_message("<span class='danger'>[user.name] slashes at the [src.name]!</span>", "<span class='notice'>You slash at the [src.name]!</span>")
+	playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
+
+	if(beenhit >= pick(3, 4) && panel_open != 1)
+		panel_open = 1
+		update_icon()
+		visible_message("<span class='danger'>The [src.name]'s cover flies open, exposing the wires!</span>")
+
+	else if(panel_open == 1 && !wires.is_all_cut())
+		wires.cut_all()
+		update_icon()
+		visible_message("<span class='danger'>The [src.name]'s wires are shredded!</span>")
+	else
+		beenhit += 1
+	return
 
 
 /obj/machinery/power/apc/interact(mob/user)


### PR DESCRIPTION
Juggernaut:
-Higher max health, starting health unchanged though. Encourages teaming up with an arti.
-Melee damage now fluctuates between 30 and 40 instead of being fixed 30
-They can see in dark now
-Bigger chance to reflect projectiles, as well as making them take less damage if they do reflect it.
Wraith:
-Can slash APCs
-Can use the para smoke
-Damage now fluctuates between 20 and 25 instead of being fixed 25
All in all, the proposed changes aim to:
-Make the juggernaut the tank he's supposed to be, instead of being a slow wall breaker that dies to any kind of ranged weapon
-Make the wraith able to do things other than kill an AI
